### PR TITLE
Cleaned up the code by specifying types where needed and simplifying imports. Moved advocate filtering to the server.

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,21 @@
+
+## Summary of changes
+- Moved the advocate filtering logic into the server so it can rely on the database
+  and its scalability to perform with a large number of rows
+- Limited the maximum number of returned advocates to 100 to prevent overloading the user's
+  browser and the db server when there is too much data. Another possible approach is to
+  implement pagination. Which approach to use should depend on product goals
+- Added types into function definitions where they were missing
+
+## Left to do:
+- UI updates
+- `ilikeInArrayElements` - this is a custom filter I defined in advocates/route.ts.
+  It contains a messy conversion that takes the contents of the `payload` column
+  (which has been seeded with a stringified JSON array rather than just an array)
+  and converts it to a jsonb array usable in Postgres. This seems to be some kind
+  of possible mis-configuration in mapping, possibly in Drizzle, but I didn't find
+  the actual cause of this.
+- The API model returned by the endpoint is not clearly typed, but ideally it would be, as well
+  as the server would provide an OpenAPI document which lists the returned model. This
+  would allow the front-end to auto-generate an API client instead of having to manually
+  create or update models on changes.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,89 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import db from "@/db";
+import { advocates } from "@/db/schema";
+import { NextRequest } from "next/server";
+import { Column, ilike, or, sql } from "drizzle-orm";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+/**
+ * Extracts the text from the array elements, then applies the ILIKE operator
+ * @param jsonbColumn the jsonb column
+ * @param searchTerm the term to search
+ */
+function ilikeInArrayElements(jsonbColumn: Column, searchTerm: string) {
+  // TODO: the messy jsonb conversion below is due to the payload column being
+  //   seeded with a stringified JSON array rather than just an array.
+  //   see DISCUSSION.md for more information
+  return sql`EXISTS (
+    SELECT 1 FROM jsonb_array_elements_text((${jsonbColumn} #>> '{}')::jsonb) AS elem
+    WHERE elem ILIKE ${`${searchTerm}`}
+  )`;
+}
 
-  const data = advocateData;
+/**
+ * Casts the values in the number column to text, then applies the ILIKE operator
+ * @param numberColumn the number column
+ * @param searchTerm the term to search
+ */
+function ilikeForNumbers(numberColumn: Column, searchTerm: string) {
+  return sql`${numberColumn}::text ILIKE ${`${searchTerm}`}`;
+}
 
-  return Response.json({ data });
+const MaxAllowedCollectionSize = 100;
+
+/**
+ * Returns advocates matching the specified search term. If no search term is specified,
+ * returns all (see DISCUSSION.md for suggested fixes)
+ * @param req the request object
+ * @constructor
+ */
+export async function GET(req: NextRequest) {
+  const searchTerm: string = req.nextUrl.searchParams.get("searchTerm") || "";
+  const data = await db?.select({
+    id: advocates.id,
+    firstName: advocates.firstName,
+    lastName: advocates.lastName,
+    city: advocates.city,
+    degree: advocates.degree,
+    specialties: advocates.specialties,
+    yearsOfExperience: advocates.yearsOfExperience,
+    phoneNumber: advocates.phoneNumber
+  }).from(advocates)
+    .where(
+      or(
+        ilike(advocates.firstName, `%${searchTerm}%`),
+        ilike(advocates.lastName, `%${searchTerm}%`),
+        ilike(advocates.city, `%${searchTerm}%`),
+        ilike(advocates.degree, `%${searchTerm}%`),
+        ilikeInArrayElements(advocates.specialties, `%${searchTerm}%`),
+        ilikeForNumbers(advocates.yearsOfExperience, `%${searchTerm}%`),
+        ilikeForNumbers(advocates.phoneNumber, `%${searchTerm}%`)
+      )
+    )
+    .limit(MaxAllowedCollectionSize);
+
+  // select only the required properties, avoid exposing the whole row, map to appropriate types
+  const apiModel: IAdvocate[] | undefined = data?.map(a => ({
+    id: a.id,
+    firstName: a.firstName,
+    lastName: a.lastName,
+    city: a.city,
+    degree: a.degree,
+    specialties: a.specialties as string[],
+    yearsOfExperience: a.yearsOfExperience,
+    phoneNumber: a.phoneNumber
+  }));
+  return Response.json({ data: apiModel });
+}
+
+/**
+ * API model of the advocate
+ */
+interface IAdvocate {
+  id: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: number;
 }

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,9 +1,18 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import db from "@/db";
+import { advocates } from "@/db/schema";
+import { advocateData } from "@/db/seed/advocates";
+import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
+/**
+ * Seeds the database with initial data
+ * @constructor
+ */
 export async function POST() {
-  const records = await db.insert(advocates).values(advocateData).returning();
+  const dbWritableContext = db as PostgresJsDatabase;
+  const records = await dbWritableContext
+    .insert(advocates)
+    .values(advocateData)
+    .returning();
 
   return Response.json({ advocates: records });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,44 +1,56 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import {ChangeEvent, useEffect, useState} from "react";
+
+/**
+ * Advocate model returned from the API request. Ideally, this would be auto-generated.
+ */
+interface IAdvocate {
+  id: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: number;
+}
+
+/**
+ * Represents a typed JSON response. Makes it easier to deserialize.
+ */
+interface IJsonResult<TData> {
+  data: TData[];
+}
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [advocates, setAdvocates] = useState<IAdvocate[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
-    console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
-    });
-  }, []);
+    (async () => {
+      console.log("fetching advocates...");
+      const response = await fetch(`/api/advocates?searchTerm=${searchTerm}`);
+      const responseJson: IJsonResult<IAdvocate> = await response.json();
+      setAdvocates(responseJson.data);
+    })();
+  }, [searchTerm]);
 
-  const onChange = (e) => {
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const searchTerm = e.target.value;
+    setSearchTerm(searchTerm);
 
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
+    const searchTermElement = document.getElementById("search-term");
+    if (searchTermElement) {
+        searchTermElement.innerHTML = searchTerm;
+    } else {
+      console.error("search-term element not found");
+    }
   };
 
   const onClick = () => {
     console.log(advocates);
-    setFilteredAdvocates(advocates);
+    setSearchTerm("");
   };
 
   return (
@@ -57,26 +69,26 @@ export default function Home() {
       <br />
       <br />
       <table>
-        <thead>
+        <thead><tr>
           <th>First Name</th>
           <th>Last Name</th>
           <th>City</th>
           <th>Degree</th>
           <th>Specialties</th>
           <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <th>Phone Number</th></tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate: IAdvocate) => {
             return (
-              <tr>
+              <tr key={advocate.id}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={`${advocate.id}{s}`}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,17 +4,12 @@ import postgres from "postgres";
 const setup = () => {
   if (!process.env.DATABASE_URL) {
     console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    return undefined;
   }
 
   // for query purposes
   const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
+  return drizzle(queryClient);
 };
 
 export default setup();


### PR DESCRIPTION
Changes in the whole codebase:
- The code used imports with a relative path like "../../../", which was simplified to just "@/"
- Types are specified where they were missing

Changes in the back-end:
- Advocate filtering was happening on the front-end, which would require the whole dataset to be loaded into the user's browser. This is not a scalable option when there are a lot of advocates. This functionality was moved to the back-end to utilize the database's scalability
- The data from the database is now mapped to a specific API model, preventing accidental data over-exposure

Changes in the front-end:
- In page.tsx, in the useEffect handler, a promise was manually constructed without async/await, this was refactored for readability
